### PR TITLE
fix: update the following actions to use node 20 warning

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,5 +46,5 @@ inputs:
     default: false
     description: 'passive'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
closes: https://github.com/sand4rt/ftp-deployer/issues/23